### PR TITLE
Commented out ADO MCP Server

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,15 +1,15 @@
 {
 	"servers": {
-		"Azure DevOps": {
-			"type": "stdio",
-			"command": "npx",
-			"args": [
-				"-y",
-				"@azure-devops/mcp",
-				"${input:ado_org}"
-			],
-			"version": "0.0.1"
-		},
+		// "Azure DevOps": {
+		// 	"type": "stdio",
+		// 	"command": "npx",
+		// 	"args": [
+		// 		"-y",
+		// 		"@azure-devops/mcp",
+		// 		"${input:ado_org}"
+		// 	],
+		// 	"version": "0.0.1"
+		// },
 		"Microsoft Learn": {
 			"url": "https://learn.microsoft.com/api/mcp",
 			"type": "http"


### PR DESCRIPTION
This pull request makes a small change to the `.vscode/mcp.json` configuration file by commenting out the configuration for the "Azure DevOps" server. This disables the Azure DevOps integration without deleting its configuration, likely for troubleshooting or to prevent conflicts with other servers.